### PR TITLE
Fix item banning by using legal none instead of illegal all

### DIFF
--- a/rulesets/1454833091171319930.json
+++ b/rulesets/1454833091171319930.json
@@ -47,7 +47,7 @@
       }
     },
     "abilities": { "legal": [], "illegal": [] },
-    "items": { "legal": [], "illegal": ["all"] }
+    "items": { "legal": ["none"], "illegal": [] }
   },
 
   "1467850676808847371": {
@@ -78,7 +78,7 @@
       }
     },
     "abilities": { "legal": [], "illegal": [] },
-    "items": { "legal": [], "illegal": ["all"] }
+    "items": { "legal": ["none"], "illegal": [] }
   },
 
   "1467850710480846989": {
@@ -109,7 +109,7 @@
       }
     },
     "abilities": { "legal": [], "illegal": [] },
-    "items": { "legal": [], "illegal": ["all"] }
+    "items": { "legal": ["none"], "illegal": [] }
   },
 
   "1467850744853041223": {
@@ -140,6 +140,6 @@
       }
     },
     "abilities": { "legal": [], "illegal": [] },
-    "items": { "legal": [], "illegal": ["all"] }
+    "items": { "legal": ["none"], "illegal": [] }
   }
 }


### PR DESCRIPTION
This PR fixes the item banning logic in the PvP arena rulesets.

Previously, items were attempted to be banned using `"illegal": ["all"]`,
which is not supported.

This update correctly bans all items by using:
`"legal": ["none"]`

No other rules were changed.